### PR TITLE
GettextTranslator::listLocales(): Only return our special `C` locales

### DIFF
--- a/src/GettextTranslator.php
+++ b/src/GettextTranslator.php
@@ -385,6 +385,15 @@ class GettextTranslator
                     continue;
                 }
 
+                list($actualLocale) = array_slice(
+                    explode(DIRECTORY_SEPARATOR, $file->getPath()),
+                    -2,
+                    1
+                );
+                if ($actualLocale !== 'C') {
+                    continue;
+                }
+
                 $locale = explode('.', $file->getBasename('.mo'));
 
                 $locales[] = array_pop($locale);


### PR DESCRIPTION
Previously, all locales (source locales if the `C` ones are symlinks) were inspected as well. Leading to invalid locales such as `icinga`.