### PR TITLE
Locale: Consider the default locale when identifiying the preferred one

### DIFF
--- a/src/Locale.php
+++ b/src/Locale.php
@@ -75,6 +75,7 @@ class Locale
             array_values($requestedLocales)
         );
 
+        $available[] = $this->defaultLocale;
         $availableLocales = array_combine(
             array_map('strtolower', array_values($available)),
             array_values($available)

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -6,7 +6,7 @@ use ipl\I18n\Locale;
 
 class LocaleTest extends \PHPUnit\Framework\TestCase
 {
-    const AVAILABLE_TRANSLATIONS = ['en_US', 'de_DE', 'de_AT'];
+    const AVAILABLE_TRANSLATIONS = ['de_DE', 'de_AT'];
 
     public function testWhetherGetPreferredFavorsPerfectMatches()
     {
@@ -41,6 +41,11 @@ class LocaleTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             'de_DE',
             (new Locale())->getPreferred('de,en', static::AVAILABLE_TRANSLATIONS),
+            'Locale::getPreferredLocale() does not return the most preferred similar match'
+        );
+        $this->assertEquals(
+            'en_US',
+            (new Locale())->getPreferred('en,de', static::AVAILABLE_TRANSLATIONS),
             'Locale::getPreferredLocale() does not return the most preferred similar match'
         );
     }


### PR DESCRIPTION
`Locale::getPreferred()` has to respect the default locale when performing matches against the given preferences.

This didn't occur in tests previously, because they included the default locale in the available locale list, which `GettextTranslator::listLocales()` doesn't.