### PR TITLE
phpstan: Scan `/usr/share/icinga-php` instead of `vendor`

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,4 +12,4 @@ parameters:
         - src
 
     scanDirectories:
-        - vendor
+        - /usr/share/icinga-php


### PR DESCRIPTION
Because this is available both locally and remotely.